### PR TITLE
Removed `self.peer.connected` usage and switched to `self._channel.readyState`

### DIFF
--- a/datachannel.js
+++ b/datachannel.js
@@ -54,10 +54,6 @@ DataChannel.prototype._setDataChannel = function (channel) {
     self.destroy(makeError(err, 'ERR_DATA_CHANNEL'))
   }
 
-  if (self.peer.connected) {
-    self._sendChunk()
-  }
-
   self._onFinishBound = function () {
     self._onFinish()
   }
@@ -70,7 +66,7 @@ DataChannel.prototype._write = function (chunk, encoding, cb) {
   var self = this
   if (self.destroyed) return cb(makeError('cannot write after channel is destroyed', 'ERR_DATA_CHANNEL'))
 
-  if (self.peer.connected && self._channel) {
+  if (self._channel && self._channel.readyState === 'open') {
     try {
       self.send(chunk)
     } catch (err) {
@@ -95,7 +91,7 @@ DataChannel.prototype._onFinish = function () {
   var self = this
   if (self.destroyed) return
 
-  if (self.peer.connected) {
+  if (!self._channel || self._channel.readyState === 'open') {
     destroySoon()
   } else {
     self.once('connect', destroySoon)
@@ -140,6 +136,7 @@ DataChannel.prototype._onChannelOpen = function () {
   self._debug('on channel open', self.channelName)
   self._channelReady = true
   self.emit('open')
+  self._sendChunk()
 }
 
 DataChannel.prototype._onChannelClose = function () {

--- a/index.js
+++ b/index.js
@@ -604,10 +604,6 @@ Peer.prototype._maybeReady = function () {
         self.connected = true
       }
 
-      self._channels.forEach(function (channel) {
-        channel._sendChunk()
-      })
-
       self._debug('connect')
       self.emit('connect')
     })


### PR DESCRIPTION
As noted in https://github.com/feross/simple-peer/pull/334 `self.peer.connected` is not the best way of doing it, so I've managed to eliminate it alongside with some simplifications.
Tested in Node.js, Firefox Nightly and Chromium Nightly.